### PR TITLE
Handle special characters correctly, handle plus signs correctly, and made code more efficient

### DIFF
--- a/connectors/jqueryFileTree.php
+++ b/connectors/jqueryFileTree.php
@@ -16,28 +16,40 @@
 // Output a list of files for jQuery File Tree
 //
 
-$_POST['dir'] = urldecode((isset($_POST['dir']) ? $_POST['dir'] : null ));
+$_POST['dir'] = rawurldecode((isset($_POST['dir']) ? $_POST['dir'] : null ));
 
 if( file_exists($_POST['dir']) ) {
-	$files = scandir($_POST['dir']);
-	natcasesort($files);
-	if( count($files) > 2 ) { // The 2 accounts for . and .. 
-		echo "<ul class=\"jqueryFileTree\" style=\"display: none;\">";
-		// All dirs
-		foreach( $files as $file ) {
-			if( file_exists($_POST['dir'] . $file) && $file != '.' && $file != '..' && is_dir($_POST['dir'] . $file) ) {
-				echo "<li class=\"directory collapsed\"><a href=\"#\" rel=\"" . htmlentities($_POST['dir'] . $file) . "/\">" . htmlentities($file) . "</a></li>";
-			}
-		}
-		// All files
-		foreach( $files as $file ) {
-			if( file_exists($_POST['dir'] . $file) && $file != '.' && $file != '..' && !is_dir($_POST['dir'] . $file) ) {
-				$ext = preg_replace('/^.*\./', '', $file);
-				echo "<li class=\"file ext_$ext\"><a href=\"#\" rel=\"" . htmlentities($_POST['dir'] . $file) . "\">" . htmlentities($file) . "</a></li>";
-			}
-		}
-		echo "</ul>";	
-	}
+   $files = scandir($_POST['dir']);
+   natcasesort($files);
+   if( count($files) > 2 ) { /* The 2 accounts for . and .. */
+      echo "<ul class=\"jqueryFileTree\" style=\"display: none;\">";
+      foreach( $files as $file ) {
+         $Path = $_POST['dir'] . $file;
+         if(!file_exists($Path) || $file == '.' || $file == '..') {
+            continue;
+         }
+         //The following lines will take care of character encoding of special characters on a windows server.
+         //Since special characters (é for example) are not displayed correctly when a file containing this character is found on a windows server.
+         //The windows-1252 encoding returned by scandir() does not display correctly in HTML, so we need to convert it to UTF-8
+         //See http://stackoverflow.com/questions/22660797/ for full details
+         //WARNING: If you have a script running (instead of directly linking to files) to send your scripts, you have to run a reverse encoding conversion over the string passed by jQueryFileTree
+         //Use the following line to revert the encoding conversion:
+         // $FilePath = iconv(mb_detect_encoding($FilePath),"WINDOWS-1252",$FilePath);
+         $file = iconv(mb_detect_encoding($file,array("WINDOWS-1252","UTF-8"),true),'UTF-8',$file);
+         $Dir = iconv(mb_detect_encoding($_POST['dir'],array("WINDOWS-1252","UTF-8"),true),'UTF-8',$_POST['dir']);
+         $RelString = htmlentities($Dir.$file);
+         if(is_dir($Path)) {
+            //Handle directories
+            echo "<li class=\"directory collapsed\"><a href=\"javascript:void(0);\" rel=\"{$RelString}/\">" . htmlentities($file) . "</a></li>";
+         }
+         else {
+            //Handle files
+            $ext = preg_replace('/^.*\./', '', $file);
+            echo "<li class=\"file ext_$ext\"><a href=\"javascript:void(0);\" rel=\"{$RelString}\">" . htmlentities($file) . "</a></li>";
+         }
+      }
+      echo "</ul>";  
+   }
 }
 
 ?>


### PR DESCRIPTION
I fixed a problem I encountered on windows apache/PHP server: Special
characters (like é) in files and folders are not handled correctly.
Running scandir() on a windows system returns files and folder names in
WINDOWS-1252 encoding, which does NOT work when calling `htmlentities()`
over them for these kind of special characters. Therefor the encoding is
converted to UTF-8 which works correctly with `htmlentities()`.

Forgot to add my initial commit:
Also changed `urlencode()` to `rawurlencode()` to handle files/directories containing a plus (+) sign correctly. `urlencode()` changes + to spaces, however it's perfectly possible (on a windows system at least) to have files/folders containing plus signs, these should remain plus signs and not be changed into spaces.

Also shortened the code/made it more efficient: Instead running 2 loops (one for files, one for directories) over the `$files` array, i changed it to one loop and handle the differences for files and directories inside the loop.
