### PR TITLE
Anchor deleted in many conectors to avoid status bar on the browser

### DIFF
--- a/dist/connectors/jqueryFileTree.asp
+++ b/dist/connectors/jqueryFileTree.asp
@@ -24,7 +24,7 @@ if ObjFSO.FolderExists(BaseFile) then
        For Each ObjSubFolder In ObjFolder.SubFolders
                i__Name=ObjSubFolder.name
                Html = Html + "<li class=""directory collapsed"">"&_
-                                         "<a href=""#"" rel="""+(BaseFileDir+i__Name+"/")+""">"&_
+                                         "<a rel="""+(BaseFileDir+i__Name+"/")+""">"&_
                                          (i__Name)+"</a></li>"&VBCRLF
        Next
        'LOOP THROUGH FILES
@@ -34,7 +34,7 @@ if ObjFSO.FolderExists(BaseFile) then
                ' extension
                i__Ext = LCase(Mid(i__Name, InStrRev(i__Name, ".", -1, 1) + 1))
                Html = Html + "<li class=""file ext_"&i__Ext&""">"&_
-                                         "<a href=""#"" rel="""+(BaseFileDir+i__Name)+""">"&_
+                                         "<a rel="""+(BaseFileDir+i__Name)+""">"&_
                                          (i__name)+"</a></li>"&VBCRLF
        Next
        Html = Html +  "</ul>"&VBCRLF

--- a/dist/connectors/jqueryFileTree.aspx
+++ b/dist/connectors/jqueryFileTree.aspx
@@ -18,14 +18,14 @@
 	System.IO.DirectoryInfo di = new System.IO.DirectoryInfo(dir);
 	Response.Write("<ul class=\"jqueryFileTree\" style=\"display: none;\">\n");
 	foreach (System.IO.DirectoryInfo di_child in di.GetDirectories())
-		Response.Write("\t<li class=\"directory collapsed\"><a href=\"#\" rel=\"" + dir + di_child.Name + "/\">" + di_child.Name + "</a></li>\n");
+		Response.Write("\t<li class=\"directory collapsed\"><a rel=\"" + dir + di_child.Name + "/\">" + di_child.Name + "</a></li>\n");
 	foreach (System.IO.FileInfo fi in di.GetFiles())
 	{
 		string ext = ""; 
 		if(fi.Extension.Length > 1)
 			ext = fi.Extension.Substring(1).ToLower();
 			
-		Response.Write("\t<li class=\"file ext_" + ext + "\"><a href=\"#\" rel=\"" + dir + fi.Name + "\">" + fi.Name + "</a></li>\n");		
+		Response.Write("\t<li class=\"file ext_" + ext + "\"><a rel=\"" + dir + fi.Name + "\">" + fi.Name + "</a></li>\n");		
 	}
 	Response.Write("</ul>");
  %>

--- a/dist/connectors/jqueryFileTree.cf
+++ b/dist/connectors/jqueryFileTree.cf
@@ -11,9 +11,9 @@ By Tjarko Rikkerink (http://carlosgallupa.com/)
 <ul class="jqueryFileTree" style="display: none;">
        <cfoutput query="qDir">
                <cfif type eq "dir">
-                   <li class="directory collapsed"><a href="##" rel="#URLDecode(form.dir)##name#/">#name#</a></li>
+                   <li class="directory collapsed"><a rel="#URLDecode(form.dir)##name#/">#name#</a></li>
                <cfelseif type eq "file">
-               <li class="file ext_#listLast(name,'.')#"><a href="##" rel="#URLDecode(form.dir)##name#">#name# (#round(size/1024)#KB)</a></li>
+               <li class="file ext_#listLast(name,'.')#"><a rel="#URLDecode(form.dir)##name#">#name# (#round(size/1024)#KB)</a></li>
                </cfif>
        </cfoutput>
 </ul>

--- a/dist/connectors/jqueryFileTree.go
+++ b/dist/connectors/jqueryFileTree.go
@@ -28,9 +28,9 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		if false == noHidden || f.Name()[0] != '.' {
 			p := path.Join(dir, f.Name())
 			if true == f.IsDir() {
-				out += fmt.Sprintf(`<li class="directory collapsed"><a href="#" rel="%s">%s</a></li>`, p+"/", f.Name())
+				out += fmt.Sprintf(`<li class="directory collapsed"><a rel="%s">%s</a></li>`, p+"/", f.Name())
 			} else {
-				out += fmt.Sprintf(`<li class="file ext_%s"><a href="#" rel="%s">%s</a></li>`, path.Ext(f.Name())[1:], p, f.Name())
+				out += fmt.Sprintf(`<li class="file ext_%s"><a rel="%s">%s</a></li>`, path.Ext(f.Name())[1:], p, f.Name())
 			}
 		}
 	}

--- a/dist/connectors/jqueryFileTree.jsp
+++ b/dist/connectors/jqueryFileTree.jsp
@@ -31,7 +31,7 @@
 		// All dirs
 		for (String file : files) {
 		    if (new File(dir, file).isDirectory()) {
-				out.print("<li class=\"directory collapsed\"><a href=\"#\" rel=\"" + dir + file + "/\">"
+				out.print("<li class=\"directory collapsed\"><a rel=\"" + dir + file + "/\">"
 					+ file + "</a></li>");
 		    }
 		}
@@ -40,7 +40,7 @@
 		    if (!new File(dir, file).isDirectory()) {
 				int dotIndex = file.lastIndexOf('.');
 				String ext = dotIndex > 0 ? file.substring(dotIndex + 1) : "";
-				out.print("<li class=\"file ext_" + ext + "\"><a href=\"#\" rel=\"" + dir + file + "\">"
+				out.print("<li class=\"file ext_" + ext + "\"><a rel=\"" + dir + file + "\">"
 					+ file + "</a></li>");
 		    	}
 		}

--- a/dist/connectors/jqueryFileTree.php
+++ b/dist/connectors/jqueryFileTree.php
@@ -54,9 +54,9 @@ if( file_exists($postDir) ) {
 
 			if( file_exists($postDir . $file) && $file != '.' && $file != '..' ) {
 				if( is_dir($postDir . $file) && (!$onlyFiles || $onlyFolders) )
-					echo "<li class='directory collapsed'>{$checkbox}<a href='#' rel='" .$htmlRel. "/'>" . $htmlName . "</a></li>";
+					echo "<li class='directory collapsed'>{$checkbox}<a rel='" .$htmlRel. "/'>" . $htmlName . "</a></li>";
 				else if (!$onlyFolders || $onlyFiles)
-					echo "<li class='file ext_{$ext}'>{$checkbox}<a href='#' rel='" . $htmlRel . "'>" . $htmlName . "</a></li>";
+					echo "<li class='file ext_{$ext}'>{$checkbox}<a rel='" . $htmlRel . "'>" . $htmlName . "</a></li>";
 			}
 		}
 

--- a/dist/connectors/jqueryFileTree.pl
+++ b/dist/connectors/jqueryFileTree.pl
@@ -49,7 +49,7 @@ print "<ul class=\"jqueryFileTree\" style=\"display: none;\">";
 foreach my $file (sort @folders) {
     next if ! -e  $fullDir . $file;
     
-    print '<li class="directory collapsed"><a href="#" rel="' . 
+    print '<li class="directory collapsed"><a rel="' . 
           &HTML::Entities::encode($dir . $file) . '/">' . 
           &HTML::Entities::encode($file) . '</a></li>';
 }
@@ -60,7 +60,7 @@ foreach my $file (sort @files) {
 
     $file =~ /\.(.+)$/;
     my $ext = $1;
-    print '<li class="file ext_' . $ext . '"><a href="#" rel="' . 
+    print '<li class="file ext_' . $ext . '"><a rel="' . 
     &HTML::Entities::encode($dir . $file) . '/">' .
     &HTML::Entities::encode($file) . '</a></li>';
 }

--- a/dist/connectors/jqueryFileTree.py
+++ b/dist/connectors/jqueryFileTree.py
@@ -14,10 +14,10 @@ def dirlist(request):
        for f in os.listdir(d):
            ff=os.path.join(d,f)
            if os.path.isdir(ff):
-               r.append('<li class="directory collapsed"><a href="#" rel="%s/">%s</a></li>' % (ff,f))
+               r.append('<li class="directory collapsed"><a rel="%s/">%s</a></li>' % (ff,f))
            else:
                e=os.path.splitext(f)[1][1:] # get .ext and remove dot
-               r.append('<li class="file ext_%s"><a href="#" rel="%s">%s</a></li>' % (e,ff,f))
+               r.append('<li class="file ext_%s"><a rel="%s">%s</a></li>' % (e,ff,f))
        r.append('</ul>')
    except Exception,e:
        r.append('Could not load directory: %s' % str(e))

--- a/dist/connectors/jqueryFileTree.rb
+++ b/dist/connectors/jqueryFileTree.rb
@@ -40,7 +40,7 @@ begin
 		Dir.glob("*") {
 			|x|
 			if not File.directory?(x.untaint) then next end 
-			puts "<li class=\"directory collapsed\"><a href=\"#\" rel=\"#{dir}#{x}/\">#{x}</a></li>";
+			puts "<li class=\"directory collapsed\"><a rel=\"#{dir}#{x}/\">#{x}</a></li>";
 		}
 
 		#loop through all files
@@ -48,7 +48,7 @@ begin
 			|x|
 			if not File.file?(x.untaint) then next end 
 			ext = File.extname(x)[1..-1]
-			puts "<li class=\"file ext_#{ext}\"><a href=\"#\" rel=\"#{dir}#{x}\">#{x}</a></li>"
+			puts "<li class=\"file ext_#{ext}\"><a rel=\"#{dir}#{x}\">#{x}</a></li>"
 		}
 	else
 		#only happens when someone tries to go outside your root directory...

--- a/dist/connectors/jqueryFileTree2.pl
+++ b/dist/connectors/jqueryFileTree2.pl
@@ -39,10 +39,10 @@ closedir($dir_handle);
 
 print "<ul class=\"jqueryFileTree\">\n";
 foreach my $directory (sort @directories) {
-    print "        <li class=\"directory collapsed\">$checkbox<a href=\"#\" rel=\"$dir_path/$directory/\">$directory</a></li>\n";
+    print "        <li class=\"directory collapsed\">$checkbox<a rel=\"$dir_path/$directory/\">$directory</a></li>\n";
 }
 foreach my $file (sort @files) {
     my $file_ext = (split /\./, $file)[1] || "";
-    print "        <li class=\"file ext_${file_ext}\">$checkbox<a href=\"#\" rel=\"$dir_path/$file\">$file</a></li>\n";
+    print "        <li class=\"file ext_${file_ext}\">$checkbox<a rel=\"$dir_path/$file\">$file</a></li>\n";
 }
 print "</ul>\n";

--- a/dist/connectors/jqueryFileTree_huck.lasso
+++ b/dist/connectors/jqueryFileTree_huck.lasso
@@ -25,10 +25,10 @@
 		#file->beginswith('.') ? loop_continue;
 	
 		if(#file->endswith('/'));
-			'<li class="directory collapsed"><a href="#" rel="' + $dir + #file + '">' + #file + '</a></li>';
+			'<li class="directory collapsed"><a rel="' + $dir + #file + '">' + #file + '</a></li>';
 		else;
 			local('ext') = #file->split('.')->last;			
-			'<li class="file ext_' + #ext + '"><a href="#" rel="' + $dir + #file + '">' + #file + '</a></li>';
+			'<li class="file ext_' + #ext + '"><a rel="' + $dir + #file + '">' + #file + '</a></li>';
 		/if;
 	/iterate;
 	

--- a/src/jQueryFileTree.css
+++ b/src/jQueryFileTree.css
@@ -12,6 +12,7 @@ UL.jqueryFileTree LI {
   padding-left: 20px;
   margin: 0;
   white-space: nowrap;
+  cursor:pointer;
 }
 UL.jqueryFileTree LI.directory {
   background: url(images/directory.png) left top no-repeat;


### PR DESCRIPTION
When your pointer is over a file or directory in the tree, the browser shows you a link in the addres bar to "#" but is more esthetic to hide this value. to the user.

* All the anchors were deleted from the connectors  (tag   href="#" ) to avoid the status bar.
* A default style was added to the list items in the tree to preserve the visual appearance when you put your mouse over an item.