### PR TITLE
Support result from callback for function script

### DIFF
--- a/src/jQueryFileTree.js
+++ b/src/jQueryFileTree.js
@@ -24,6 +24,7 @@ var bind = function(fn, me){ return function(){ return fn.apply(me, arguments); 
       _this = this;
       defaults = {
         root: '/',
+        scriptFunctionHasCallback: false,
         script: '/files/filetree',
         folderEvent: 'click',
         expandSpeed: 500,
@@ -164,11 +165,19 @@ var bind = function(fn, me){ return function(){ return fn.apply(me, arguments); 
         return false;
       };
       if (typeof options.script === 'function') {
-        result = options.script(data);
-        if (typeof result === 'string' || result instanceof jQuery) {
-          return handleResult(result);
+        function gotResult(result) {
+          if (typeof result === 'string' || result instanceof jQuery) {
+            return handleResult(result);
+          } else {
+            return handleFail();
+          }
+        }
+        if (options.scriptFunctionHasCallback) {
+          options.script(data, function(result) {
+            gotResult(result);
+          });
         } else {
-          return handleFail();
+          gotResult(options.script(data));
         }
       } else {
         return $.ajax({


### PR DESCRIPTION
The expected markup may be obtained from a callback source.
By setting the option 'scriptFunctionHasCallback', the user can return a result by callback e.g.

$('#tree').fileTree({
  root: '/root/path'
  scriptFunctionHasCallback: true,
  script: function(data, callback) {
    getDataFromSomewhere(function(data) {
      var html = '';
      //... generate html from data
      callback(html);
    });
  }
});

This patch does not break or remove synchronous sources, it only adds support for asynchronous sources